### PR TITLE
Fix #9

### DIFF
--- a/app/classes/CryptoStatus.php
+++ b/app/classes/CryptoStatus.php
@@ -225,7 +225,7 @@ class CryptoStatus {
       }
     }
 
-    if (count($tweet_ids) == 3) {
+    if (!empty($tweet_ids) && count($tweet_ids) == 3) {
       return true;
     } else {
       $this->failed_tweets = $tweet_ids;


### PR DESCRIPTION
Prevent warning "count(): Parameter must be an array or an object that implements Countable"