### PR TITLE
why init first and then run?

### DIFF
--- a/app/app.php
+++ b/app/app.php
@@ -31,8 +31,5 @@ $bugsnag_client = new BugsnagClient;
 
 $app = new CryptoStatus;
 
-// initialize app
-$app->init();
-
-// run app
+// initialize and run the app
 $app->run();

--- a/app/classes/CryptoStatus.php
+++ b/app/classes/CryptoStatus.php
@@ -96,6 +96,9 @@ class CryptoStatus {
    * Run the application
    */
   public function run() {
+
+    $this->init();
+
     $this->dataset = $this->getDataset();
 
     $this->formatData();


### PR DESCRIPTION
Let the run-function start by running the init function. since neither takes arguments and has no relation to anything else there's no reason to have both in app.php